### PR TITLE
posts: fixup scrollbar and posts list display

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -137,3 +137,12 @@ pub fn split_cells(text: &str, width: usize, out: &mut [String]) -> usize {
 
     height
 }
+
+/// Gets the wrapped height of provided text width.
+pub fn wrapped_height(text_width: usize, screen_width: usize) -> usize {
+    if screen_width == 0 {
+        0
+    } else {
+        (text_width / screen_width).saturating_add(text_width % screen_width) + 1
+    }
+}

--- a/src/screen/post.rs
+++ b/src/screen/post.rs
@@ -71,8 +71,8 @@ pub fn draw_post_screen(
 
                 let post_text = Paragraph::new(lines)
                     .style(body_style())
-                    .block(title_block("temi : Post"))
-                    .wrap(Wrap { trim: true })
+                    .block(title_block("Post"))
+                    .wrap(Wrap { trim: false })
                     .scroll((app.vertical_scroll as u16, app.horizontal_scroll as u16));
 
                 f.render_widget(post_text, chunks[0]);
@@ -144,8 +144,8 @@ pub fn draw_post_screen(
 
                 let comment_block = Paragraph::new(comments)
                     .style(body_style())
-                    .block(title_block("temi : Comments"))
-                    .wrap(Wrap { trim: true })
+                    .block(title_block("Comments"))
+                    .wrap(Wrap { trim: false })
                     .scroll((app.vertical_scroll as u16, app.horizontal_scroll as u16));
 
                 f.render_widget(comment_block, chunks[1]);

--- a/src/screen/post.rs
+++ b/src/screen/post.rs
@@ -10,11 +10,11 @@ use crossterm::event;
 use tui::{prelude::*, widgets::scrollbar};
 
 use crate::{
-    app::{App, TemiTerminal},
+    app::{App, Scroll, TemiTerminal},
     Result,
 };
 
-use super::{body_style, set_current_screen, title_block, Screen};
+use super::{body_style, set_current_screen, title_block, wrapped_height, Screen};
 
 /// Draw the screen to show an individual [Post](crate::posts::Post).
 pub fn draw_post_screen(
@@ -35,6 +35,7 @@ pub fn draw_post_screen(
                                  Constraint::Percentage(60),
                                  Constraint::Percentage(5),
                                  Constraint::Percentage(5),
+                                 Constraint::Min(1),
                     ]
                     .as_ref(),
                     )
@@ -50,11 +51,7 @@ pub fn draw_post_screen(
                 let title = p.post.name();
                 let body = p.post.body();
 
-                let max_width = [title.len(), info.len(), published.len(), body.len()]
-                    .iter()
-                    .max()
-                    .map(|&m| m as u16)
-                    .unwrap_or(body.len() as u16);
+                let post_lens = [title.len(), info.len(), published.len(), body.len()];
 
                 let lines = vec![
                     Line::from(title),
@@ -66,33 +63,36 @@ pub fn draw_post_screen(
                     Line::from(url),
                 ];
 
-                app.vertical_scroll_state = app.vertical_scroll_state.content_length(lines.len() as u16);
-                app.horizontal_scroll_state = app.horizontal_scroll_state.content_length(max_width);
+                let posts_height: usize = wrapped_height(post_lens.iter().sum(), size.width as usize);
+                app.post_scroll.set_content_length(posts_height as u16);
+                //app.post_scroll.set_viewport_length((size.height as f32 * 0.3) as u16);
 
                 let post_text = Paragraph::new(lines)
                     .style(body_style())
                     .block(title_block("Post"))
                     .wrap(Wrap { trim: false })
-                    .scroll((app.vertical_scroll as u16, app.horizontal_scroll as u16));
+                    .scroll((app.post_scroll.position(), 0));
 
                 f.render_widget(post_text, chunks[0]);
 
+                let orientation = ScrollbarOrientation::VerticalRight;
                 let post_scrollbar = Scrollbar::default()
-                    .orientation(ScrollbarOrientation::VerticalRight)
+                    .orientation(orientation.clone())
                     .symbols(scrollbar::VERTICAL)
                     .begin_symbol(Some("▲"))
                     .end_symbol(Some("▼"));
 
                 f.render_stateful_widget(
                     post_scrollbar,
-                    chunks[0].inner(&Margin{ vertical: 1, horizontal: 0 }),
-                    &mut app.vertical_scroll_state,
+                    chunks[0].inner(&Scroll::margin()),
+                    &mut app.post_scroll.state,
                 );
 
                 // multiple `Line`s per-comment for spacing/formatting
                 let cap = app.comments[&p.post.id()].items.len() * 5;
                 let mut comments: Vec<Line> = Vec::with_capacity(cap);
 
+                let mut comment_height = 0;
                 if let Some(c) = app.comments.get_mut(&p.post.id()) {
                     c.items
                         .sort_by(|cr, cs| {
@@ -127,46 +127,51 @@ pub fn draw_post_screen(
                         let a = cr.creator.name();
                         let n = cr.counts.child_count();
                         let tabs = "►".repeat(cr.comment.path.split('.').count().saturating_sub(2));
-                        let blocks = "█".repeat(cr.comment.path.split('.').count().saturating_sub(2));
+                        let blocks = "_".repeat(cr.comment.path.split('.').count().saturating_sub(2));
 
                         let info = format!("[ author: {a}, child comments: {n} ]");
+
+                        let height = ct.len() + a.len() + tabs.len() + blocks.len() + info.len();
+                        comment_height += wrapped_height(height, size.width as usize) + 2;
 
                         // FIXME: comment indentation, child comments should be indented by depth
                         // e.g. <parent>.<child0>, one level indent
                         //      <parent>.<child0>.<subchild0> two level indent, etc.
                         comments.push(Line::from(vec![Span::raw(tabs.clone()), Span::raw(" "), Span::raw(ct)]));
-                        comments.push(Line::from(""));
                         comments.push(Line::from(vec![Span::raw(blocks), Span::raw(" "), Span::raw(info)]));
                         comments.push(Line::from(""));
                         comments.push(Line::from(""));
                     }
                 }
 
+                app.comment_scroll.set_content_length(comment_height as u16);
+                //app.comment_scroll.set_viewport_length((size.height as f32 * 0.6) as u16);
+
                 let comment_block = Paragraph::new(comments)
                     .style(body_style())
                     .block(title_block("Comments"))
                     .wrap(Wrap { trim: false })
-                    .scroll((app.vertical_scroll as u16, app.horizontal_scroll as u16));
+                    .scroll((app.comment_scroll.position(), 0));
 
                 f.render_widget(comment_block, chunks[1]);
 
                 let comment_scrollbar = Scrollbar::default()
-                    .orientation(ScrollbarOrientation::VerticalRight)
+                    .orientation(orientation.clone())
                     .symbols(scrollbar::VERTICAL)
                     .begin_symbol(Some("▲"))
                     .end_symbol(Some("▼"));
 
                 f.render_stateful_widget(
                     comment_scrollbar,
-                    chunks[0].inner(&Margin{ vertical: 1, horizontal: 0 }),
-                    &mut app.vertical_scroll_state,
+                    chunks[1].inner(&Scroll::margin()),
+                    &mut app.comment_scroll.state,
                 );
 
                 let hud = Block::default()
-                    .title("| (q) quit | (Enter) select | (◄, ▲, ▼, ►) scroll | (n) next | (p) previous |")
+                    .title("| (q) quit | (Enter) select | (▲, ▼) scroll post | (j, k) scroll comment | (n) next | (p) previous |")
                     .title_alignment(Alignment::Right);
 
-                f.render_widget(hud, chunks[3]);
+                f.render_widget(hud, chunks[4]);
             }
             _ => set_current_screen(Screen::PostList),
         }
@@ -177,32 +182,22 @@ pub fn draw_post_screen(
             match event.code {
                 event::KeyCode::Esc => set_current_screen(Screen::PostList),
                 event::KeyCode::Enter => set_current_screen(Screen::CommentList),
-                event::KeyCode::Up => {
-                    app.vertical_scroll = app.vertical_scroll.saturating_sub(1);
-                    app.vertical_scroll_state = app
-                        .vertical_scroll_state
-                        .position(app.vertical_scroll as u16);
+                event::KeyCode::Up => app.post_scroll.prev(),
+                event::KeyCode::Down => app.post_scroll.next(),
+                event::KeyCode::Char('k') => app.comment_scroll.prev(),
+                event::KeyCode::Char('j') => app.comment_scroll.next(),
+                event::KeyCode::Char('n') => {
+                    app.post_scroll.first();
+                    app.comment_scroll.first();
+
+                    app.posts.next()
                 }
-                event::KeyCode::Down => {
-                    app.vertical_scroll = app.vertical_scroll.saturating_add(1);
-                    app.vertical_scroll_state = app
-                        .vertical_scroll_state
-                        .position(app.vertical_scroll as u16);
+                event::KeyCode::Char('p') => {
+                    app.post_scroll.first();
+                    app.comment_scroll.first();
+
+                    app.posts.previous()
                 }
-                event::KeyCode::Left => {
-                    app.horizontal_scroll = app.horizontal_scroll.saturating_sub(1);
-                    app.horizontal_scroll_state = app
-                        .horizontal_scroll_state
-                        .position(app.horizontal_scroll as u16);
-                }
-                event::KeyCode::Right => {
-                    app.horizontal_scroll = app.horizontal_scroll.saturating_add(1);
-                    app.horizontal_scroll_state = app
-                        .horizontal_scroll_state
-                        .position(app.horizontal_scroll as u16);
-                }
-                event::KeyCode::Char('n') => app.posts.next(),
-                event::KeyCode::Char('p') => app.posts.previous(),
                 event::KeyCode::Char('i') => set_current_screen(Screen::Image),
                 event::KeyCode::Char('c') => {
                     if event.modifiers == event::KeyModifiers::CONTROL {


### PR DESCRIPTION
Uses separate scrollbars for post and comment section to allow for independent scrolling.

Changes the layout for the `Posts` listing for a better display.

Unfortunately, `Tables` in `ratatui` don't have the ability to add a scroll, so lines longer than the display width will be cut off.