### PR TITLE
comments: fix comment sorting to recursively sort

### DIFF
--- a/src/comments/comment.rs
+++ b/src/comments/comment.rs
@@ -89,6 +89,12 @@ impl Comment {
     }
 }
 
+impl Default for Comment {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// List of [Comment]s for displaying in the TUI.
 #[derive(Clone, Debug)]
 pub struct CommentList {

--- a/src/posts/creator.rs
+++ b/src/posts/creator.rs
@@ -18,6 +18,24 @@ pub struct Creator {
 }
 
 impl Creator {
+    /// Creates a new [Creator].
+    pub const fn new() -> Self {
+        Self {
+            id: 0,
+            name: String::new(),
+            avatar: None,
+            banned: false,
+            published: String::new(),
+            actor_id: String::new(),
+            local: false,
+            icon: None,
+            deleted: false,
+            admin: false,
+            bot_account: false,
+            instance_id: 0,
+        }
+    }
+
     /// Gets the [Creator] name.
     pub fn name(&self) -> &str {
         self.name.as_str()

--- a/src/posts/post.rs
+++ b/src/posts/post.rs
@@ -14,6 +14,20 @@ pub struct Post {
 }
 
 impl Post {
+    /// Creates a new [Post].
+    pub const fn new() -> Self {
+        Self {
+            id: 0,
+            name: String::new(),
+            url: None,
+            deleted: false,
+            nsfw: false,
+            thumbnail_url: None,
+            ap_id: String::new(),
+            body: None,
+        }
+    }
+
     /// Gets the [Post] name.
     pub fn name(&self) -> &str {
         self.name.as_str()


### PR DESCRIPTION
Sorts comments recursively, grouping by parent-child relation.

Downloads all comments for a post by setting the highest accepted limit, and downloading each page until the last chunk is reached. Downloads any remaining comments not divisible into the max limit number of comments.